### PR TITLE
Add date info and days remaining to challenge list

### DIFF
--- a/app/model/Challenge.php
+++ b/app/model/Challenge.php
@@ -246,6 +246,7 @@ class Challenge extends BaseModel
                 C.final_value,
                 A.name activity_name,
                 CU.active,
+                C.start_at,
                 C.end_at,
                 LT.mark log_type_mark
             FROM

--- a/app/presenters/ChallengePresenter.php
+++ b/app/presenters/ChallengePresenter.php
@@ -71,6 +71,7 @@ class ChallengePresenter extends LoginBasePresenter
         $this->template->title = 'Challenges';
         $this->template->challenges = $this->challengeModel->getUserChallenges();
         $this->template->editPermission = ($this->user->getIdentity()->role <= Role::MODERATOR);
+        $this->template->now = new \DateTime();
         $this['challengeForm']['challengeForm']
             ->addSubmit('submit', 'Create')
             ->getControlPrototype()

--- a/app/templates/Challenge/default.latte
+++ b/app/templates/Challenge/default.latte
@@ -18,6 +18,7 @@
                     <th>Name</th>
                     <th>Activity</th>
                     <th>Your performance</th>
+                    <th>Info</th>
                     <th colspan="2">Action</th>
                 </tr>
                 </thead>
@@ -35,6 +36,17 @@
                         <td>
                             {$challenge->current_value}/{$challenge->final_value} {$challenge->log_type_mark}
                             {if $challenge->current_value >= $challenge->final_value}✅{/if}
+                        </td>
+                        <td>
+                            {if $challenge->start_at > $now}
+                                {php $totalDays = $challenge->start_at->diff($challenge->end_at)->days + 1}
+                                🗓 {$challenge->start_at|date:'j.n.Y'} – {$challenge->end_at|date:'j.n.Y'} ({$totalDays} {if $totalDays === 1}day{else}days{/if})
+                            {elseif $challenge->end_at > $now}
+                                {php $daysLeft = $challenge->end_at->diff($now)->days + 1}
+                                {$daysLeft} {if $daysLeft === 1}day{else}days{/if} left
+                            {else}
+                                <span class="text-muted">{$challenge->start_at|date:'j.n.Y'} – {$challenge->end_at|date:'j.n.Y'}</span>
+                            {/if}
                         </td>
                         <td style="width: 65px;">
                             {if $challenge->end_at > $now}
@@ -76,6 +88,15 @@
                             <small class="text-muted">
                                 {$challenge->activity_name} · {$challenge->current_value}/{$challenge->final_value} {$challenge->log_type_mark}
                                 {if $challenge->current_value >= $challenge->final_value}✅{/if}
+                                {if $challenge->start_at > $now}
+                                    {php $totalDays = $challenge->start_at->diff($challenge->end_at)->days + 1}
+                                    <br><span class="text-nowrap">🗓 {$challenge->start_at|date:'j.n.Y'} – {$challenge->end_at|date:'j.n.Y'} ({$totalDays} {if $totalDays === 1}day{else}days{/if})</span>
+                                {elseif $challenge->end_at > $now}
+                                    {php $daysLeft = $challenge->end_at->diff($now)->days + 1}
+                                    · {$daysLeft} {if $daysLeft === 1}day{else}days{/if} left
+                                {else}
+                                    · <span class="text-muted">{$challenge->start_at|date:'j.n.Y'} – {$challenge->end_at|date:'j.n.Y'}</span>
+                                {/if}
                             </small>
                         </div>
                         <div class="ml-2 text-nowrap flex-shrink-0">


### PR DESCRIPTION
## Summary
- Show **days remaining** for active (running) challenges
- Show **date range with duration** (calendar icon) for future challenges
- Show **greyed-out date range** for past challenges
- New "Info" column in desktop table, inline info in mobile cards
- Mobile: future challenge dates use `text-nowrap` to prevent awkward line breaks

## Test plan
- [ ] Verify active challenges show "X days left"
- [ ] Verify future challenges show "🗓 1.4.2026 – 30.4.2026 (30 days)"
- [ ] Verify past challenges show greyed-out date range
- [ ] Check mobile layout doesn't break with long date strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Info" column to the Challenges table displaying temporal details based on challenge status. Upcoming challenges show date ranges with total days, active challenges display remaining days, and past challenges show completion dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->