### PR TITLE
Remove breadcrumb navigation from all pages

### DIFF
--- a/app/templates/Challenge/detail.latte
+++ b/app/templates/Challenge/detail.latte
@@ -1,12 +1,6 @@
 {block content}
 
 {include '../partial/navigation.latte'}
-<ol class="breadcrumb mb-4">
-    <li class="breadcrumb-item">Dashboard</li>
-    <li class="breadcrumb-item">Challenges</li>
-    <li class="breadcrumb-item active">Challenge</li>
-</ol>
-
 {include '../partial/flashMessages.latte'}
 
 <div class="row">

--- a/app/templates/Challenge/edit.latte
+++ b/app/templates/Challenge/edit.latte
@@ -1,12 +1,6 @@
 {block content}
 {include '../partial/navigation.latte'}
 
-<ol class="breadcrumb mb-4">
-    <li class="breadcrumb-item">Dashboard</li>
-    <li class="breadcrumb-item active">Challenges</li>
-    <li class="breadcrumb-item active">Edit challenge</li>
-</ol>
-
 {include '../partial/flashMessages.latte'}
 
 {control challengeForm}

--- a/app/templates/Friends/default.latte
+++ b/app/templates/Friends/default.latte
@@ -3,10 +3,6 @@
 {include '../partial/navigation.latte'}
 {/snippetArea}
 
-<ol class="breadcrumb mb-4">
-    <li class="breadcrumb-item">Dashboard</li>
-    <li class="breadcrumb-item active">Friends</li>
-</ol>
 {include '../partial/flashMessages.latte'}
 
 {if !empty($friendshipOfferList)}

--- a/app/templates/Group/create.latte
+++ b/app/templates/Group/create.latte
@@ -1,10 +1,5 @@
 {block content}
 {include '../partial/navigation.latte'}
-    <ol class="breadcrumb mb-4">
-        <li class="breadcrumb-item">Dashboard</li>
-        <li class="breadcrumb-item"><a n:href="Group:default">Groups</a></li>
-        <li class="breadcrumb-item active">Create Group</li>
-    </ol>
     {include '../partial/flashMessages.latte'}
 
     {control groupForm}

--- a/app/templates/Group/default.latte
+++ b/app/templates/Group/default.latte
@@ -1,9 +1,5 @@
 {block content}
 {include '../partial/navigation.latte'}
-    <ol class="breadcrumb mb-4">
-        <li class="breadcrumb-item">Dashboard</li>
-        <li class="breadcrumb-item active">Groups</li>
-    </ol>
     {include '../partial/flashMessages.latte'}
 
     <a class="btn btn-success mb-3" n:href="Group:create">Create Group</a>

--- a/app/templates/Group/detail.latte
+++ b/app/templates/Group/detail.latte
@@ -1,10 +1,5 @@
 {block content}
 {include '../partial/navigation.latte'}
-    <ol class="breadcrumb mb-4">
-        <li class="breadcrumb-item">Dashboard</li>
-        <li class="breadcrumb-item"><a n:href="Group:default">Groups</a></li>
-        <li class="breadcrumb-item active">{$group->name}</li>
-    </ol>
     {include '../partial/flashMessages.latte'}
 
     <div class="card mb-3">

--- a/app/templates/Group/edit.latte
+++ b/app/templates/Group/edit.latte
@@ -1,10 +1,5 @@
 {block content}
 {include '../partial/navigation.latte'}
-    <ol class="breadcrumb mb-4">
-        <li class="breadcrumb-item">Dashboard</li>
-        <li class="breadcrumb-item"><a n:href="Group:default">Groups</a></li>
-        <li class="breadcrumb-item active">Edit Group</li>
-    </ol>
     {include '../partial/flashMessages.latte'}
 
     {control groupForm}

--- a/app/templates/Main/addWorkout.latte
+++ b/app/templates/Main/addWorkout.latte
@@ -1,9 +1,5 @@
 {block content}
 {include '../partial/navigation.latte'}
-    <ol class="breadcrumb mb-4">
-        <li class="breadcrumb-item">Dashboard</li>
-        <li class="breadcrumb-item active">Add Workout</li>
-    </ol>
     {include '../partial/flashMessages.latte'}
 
     <div class="card mb-3">

--- a/app/templates/User/edit.latte
+++ b/app/templates/User/edit.latte
@@ -1,12 +1,6 @@
 {block content}
 {include '../partial/navigation.latte'}
 
-<ol class="breadcrumb mb-4">
-    <li class="breadcrumb-item">Dashboard</li>
-    <li class="breadcrumb-item">User</li>
-    <li class="breadcrumb-item active">Edit</li>
-</ol>
-
 <div class="row">
     <div class="col-xl-4 col-sm-6 mb-3">
         {control userProfileForm}

--- a/app/templates/User/profile.latte
+++ b/app/templates/User/profile.latte
@@ -1,11 +1,6 @@
 {block content}
 {include '../partial/navigation.latte'}
 
-<ol class="breadcrumb mb-4">
-    <li class="breadcrumb-item">Dashboard</li>
-    <li class="breadcrumb-item">User</li>
-    <li class="breadcrumb-item active">Profile</li>
-</ol>
 <h1>Profile</h1>
 <a n:href="User:edit">edit profile</a> <br />
 <img style="max-width: 250px" src="{plink Static:getProfilePicture, $user['profile_photo']}"><br /><br />


### PR DESCRIPTION
## Summary
- Remove non-functional breadcrumb navigation from all 10 templates
- Affected pages: Challenge (list, detail, edit), Main (addWorkout), User (edit, profile), Friends, Group (list, detail, create, edit)

## Why
The breadcrumbs were not clickable and took up space without providing any value.

## Test plan
- [ ] Verify all pages render correctly without breadcrumbs
- [ ] Check no layout shifts or broken spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed breadcrumb navigation from multiple pages, including Challenge, Friends, Group, User, and Workout sections, for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->